### PR TITLE
Fixed getByName throws error when menu not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.*"
+        "illuminate/support": "6.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
                 "SoeurngSar\\MenuBuilder\\MenuServiceProvider"
             ],
             "aliases": {
-                "Menu": "SoeurngSar\\MenuBuilder\\Facades\\Menu"
+                "Menu": "SoeurngSar\\MenuBuilder\\app\\Facades\\Menu"
             }
         }
     }

--- a/src/WMenu.php
+++ b/src/WMenu.php
@@ -84,7 +84,7 @@ class WMenu
 
     public static function getByName($name)
     {
-        $menu_id = Menus::byName($name)->id;
+        $menu_id = optional(Menus::byName($name))->id;
         return self::get($menu_id);
     }
 


### PR DESCRIPTION
Get by name should return empty array if menu not found.